### PR TITLE
Add deprecation attribute for `Client.new`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -674,6 +674,7 @@ impl Client {
 
     /// Create a new client with a timeout in seconds
     /// # Errors
+    #[deprecated(note = "To be marked private in a future major release. Please use `new_with_headers` instead.")]
     pub fn new_with_timeout(base_url: &str, timeout: u64) -> Result<Self, Error> {
         let mut client = Self::new(base_url)?;
         client.timeout_in_secs = timeout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,7 +673,9 @@ impl Client {
 
     /// Create a new client with a timeout in seconds
     /// # Errors
-    #[deprecated(note = "To be marked private in a future major release. Please use `new_with_headers` instead.")]
+    #[deprecated(
+        note = "To be marked private in a future major release. Please use `new_with_headers` instead."
+    )]
     pub fn new_with_timeout(base_url: &str, timeout: u64) -> Result<Self, Error> {
         let mut client = Self::new(base_url)?;
         client.timeout_in_secs = timeout;


### PR DESCRIPTION
### What

Related to https://github.com/stellar/stellar-cli/issues/1728


### Why


`Client.new` should be deprecated in favor of `Client.new_with_headers` so we can pass in any rpc provider auth headers that may be necessary. In this case, instead of removing the fn, we can mark it as private.

### Known limitations

Should we also add a deprecation attribute for `new_with_timeout` too?
