### PR TITLE
Add support for auth mode in simulated transactions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1006,6 +1006,7 @@ impl Client {
             Some(AuthMode::RecordAllowNonRoot) => {
                 params.insert("authMode", "record_allow_nonroot")?;
             }
+            None => {}
         }
 
         let sim_res = self.client().request("simulateTransaction", params).await?;


### PR DESCRIPTION
### What

Simulated transactions now have an optional `authMode` parameter that enables non-root authorization.

### Why

To support P23

### Known limitations

N/A
