### PR TITLE
Update LedgerEntryChange to allow for null type value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,18 +494,11 @@ pub struct SimulateHostFunctionResult {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
-#[serde(tag = "type")]
-pub enum LedgerEntryChange {
-    #[serde(rename = "created")]
-    Created { key: String, after: String },
-    #[serde(rename = "deleted")]
-    Deleted { key: String, before: String },
-    #[serde(rename = "updated")]
-    Updated {
-        key: String,
-        before: String,
-        after: String,
-    },
+pub struct LedgerEntryChange {
+    r#type: Option<String>,
+    key: Option<String>,
+    before: Option<String>,
+    after: Option<String>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Default, Clone)]


### PR DESCRIPTION
### What
Change `LedgerEntryChange` field types to be Options to allow for null or empty values.

### Why

We were seeing an error on the CLI side when trying to simulate a tx:

```
echo "AAAAAgAAAADp7W3wVsKflcu2oYeWkUHxtnBBCWOJanEY6g2/JsosaQAAAGQAAdGqAAAACgAAAAAAAAAAAAAAAQAAAAAAAAAYAAAAAAAAAAHuPhvT9WyPCo67nW/UAUGotXDQZSbSYh9FpBnsI5J11AAAAAh0cmFuc2ZlcgAAAAMAAAASAAAAAAAAAADp7W3wVsKflcu2oYeWkUHxtnBBCWOJanEY6g2/JsosaQAAABIAAAABoeKbCt4jbO6EsUOcKJvLkpliE2cs36BamoHQUfoMgFcAAAADAAAABQAAAAAAAAAAAAAAAA==" | stellar tx simulate

❌ error: Parse error: unknown variant ``, expected one of `created`, `deleted`, `updated` at line 1 column 2219
```

This was happening because the rpc server is returning a LedgerEntryChange with empty or null values:

```
state_changes: Some([LedgerEntryChange { type: Some(""), key: None, before: None, after: None }, LedgerEntryChange { type: Some("updated"), key: Some("AAAABgAAAAHuPhvT9WyPCo67nW/UAUGotXDQZSbSYh9FpBnsI5J11AAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAADp7W3wVsKflcu2oYeWkUHxtnBBCWOJanEY6g2/JsosaQAAAAE="), before: Some("AAN0zgAAAAYAAAAAAAAAAe4+G9P1bI8Kjrudb9QBQai1cNBlJtJiH0WkGewjknXUAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAOntbfBWwp+Vy7ahh5aRQfG2cEEJY4lqcRjqDb8myixpAAAAAQAAAAMAAAACAAAAAA=="), after: Some("AAN0zgAAAAYAAAAAAAAAAe4+G9P1bI8Kjrudb9QBQai1cNBlJtJiH0WkGewjknXUAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAOntbfBWwp+Vy7ahh5aRQfG2cEEJY4lqcRjqDb8myixpAAAAAQAAAAMAAAABAAAAAA==") },
```

And, our previous serde parsing implementation wasn't able to handle that. This change mirrors what is coming from the rpc server, and allows for the type field to be an option.

### Known limitations

This change is a bit naive in that it assumes that all of the LedgerEntryChange fields can be optional. I think that this should be ok, since it more closely mirrors what is coming from the rpc server, but I'd love another set of eyes on that. 