### PR TITLE
Update stellar-strkey to 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,8 @@ dependencies = [
 [[package]]
 name = "stellar-strkey"
 version = "0.0.18"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,12 +522,13 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+ "zeroize",
 ]
 
 [[package]]
@@ -1402,7 +1414,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "stellar-xdr",
  "termcolor",
  "termcolor_output",
@@ -1416,19 +1428,20 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.16"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "data-encoding",
  "heapless",
+ "zeroize",
 ]
 
 [[package]]
@@ -1439,7 +1452,7 @@ checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
 dependencies = [
  "base64",
  "cfg_eval",
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "escape-bytes",
  "ethnum",
  "hex",
@@ -2098,6 +2111,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "stellar-xdr",
  "termcolor",
  "termcolor_output",
@@ -1434,9 +1434,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+version = "0.0.18"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib"]
 
 
 [dependencies]
-stellar-strkey = "0.0.16"
+stellar-strkey = "0.0.17"
 stellar-xdr = { version = "27.0.0", features = ["std", "serde", "base64"] }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib"]
 
 
 [dependencies]
-stellar-strkey = "0.0.17"
+stellar-strkey = "0.0.18"
 stellar-xdr = { version = "27.0.0", features = ["std", "serde", "base64"] }
 
 
@@ -38,3 +38,9 @@ sha2 = "0.10.7"
 jsonrpsee-http-client = "0.26.0"
 jsonrpsee-core = "0.26.0"
 http = "1.4.1"
+
+# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
+# the release/v0.0.18 branch so this PR can be validated against the actual
+# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,3 @@ sha2 = "0.10.7"
 jsonrpsee-http-client = "0.26.0"
 jsonrpsee-core = "0.26.0"
 http = "1.4.1"
-
-# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
-# the release/v0.0.18 branch so this PR can be validated against the actual
-# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
-[patch.crates-io]
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }


### PR DESCRIPTION
### What

Bump the direct `stellar-strkey` dependency from 0.0.16 to 0.0.18 in `Cargo.toml`, and update `Cargo.lock` accordingly. The transitive `stellar-strkey` 0.0.13 (pulled in via published `stellar-xdr` 27.0.0) is unchanged.

### Why

This adopts the latest `stellar-strkey` release, which targets the stellar-strkey release line for protocol 28. Keeping the direct dependency current ensures the RPC client builds against the up-to-date strkey API. `cargo check` passes with no source changes required.

This supersedes the earlier 0.0.17 bump: 0.0.17 contained a CLI bug (`Decoded<Strkey>` rejected owned JSON keys, breaking `strkey encode`), fixed in 0.0.18 by stellar/rs-stellar-strkey#125.

### Known limitations

N/A

---

## Protocol 28 coordination

⚠️ This change targets versions of software that will ship for **Protocol 28**, and should **not** be merged unless this repository is ready to accept Protocol 28 changes.

This is one of a coordinated set of PRs bumping `stellar-strkey` to **0.0.18** across the Protocol 28 component stack. It is preferred that all Protocol 28 releases of these components depend on the **same** version of `stellar-strkey`:

- stellar/rs-stellar-xdr#547
- stellar/rs-soroban-env#1694
- stellar/rs-soroban-sdk#1913
- stellar/rs-stellar-rpc-client#99
- stellar/stellar-cli#2614

`stellar-strkey` 0.0.18 raises the minimum supported Rust version to 1.87 and updates/adds transitive dependencies (`heapless` 0.9, `zeroize`), so MSRV and supply-chain policy (cargo-deny / cackle) updates may be required in some repositories before CI is green.