### PR TITLE
Update stellar-xdr to 28.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,7 +1427,7 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
@@ -1426,20 +1437,20 @@ version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
  "heapless",
 ]
 
 [[package]]
 name = "stellar-xdr"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+checksum = "f93d09ff8b9f919b084f664003c4c546ac66a76affd5429460dbe29f4b326f8e"
 dependencies = [
  "base64",
  "cfg_eval",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 stellar-strkey = "0.0.16"
-stellar-xdr = { version = "27.0.0", features = ["std", "serde", "base64"] }
+stellar-xdr = { version = "28.0.0", features = ["std", "serde", "base64"] }
 
 
 termcolor = "1.1.3"


### PR DESCRIPTION
> [!NOTE]
> Part of a stack of PRs that must merge in this order.
> 
> A first group of PRs deliver const-encoded contract specs, so that contract specs are produced at compile time instead of at proc-macro execution time. This provides the foundation for the capability to construct the specs from information that is not known at proc-macro execution and only known at compile time, like the fully qualified name of a type:
> 1. stellar/rs-stellar-xdr#560
> 1. stellar/rs-stellar-xdr#562
> 1. stellar/rs-soroban-sdk#1965
>
> A second group of PRs deliver fully qualified type names in contract specs. Instead of a type having the name `Context` it will have the name `soroban_sdk::auth::Context`. Qualified type names make it possible to uniquely identify types in the spec, even when they have the same name. This resolves several problems with contract specs the type identify problem (https://github.com/stellar/rs-soroban-sdk/issues/1570), type aliases limitations (https://github.com/stellar/rs-soroban-sdk/issues/1857 https://github.com/stellar/rs-soroban-sdk/issues/1063), and optimise spec shaking data section size (https://github.com/stellar/rs-soroban-sdk/issues/1978):
> 1. stellar/stellar-xdr#312
> 1. stellar/rs-stellar-xdr#566
> 1. stellar/rs-soroban-sdk#1970
> 1. stellar/rs-stellar-rpc-client#108 ← this PR
> 1. stellar/stellar-cli#2674

### What

Update `stellar-xdr` to 28.0.0.

### Why

Downstream consumers moving to stellar-xdr 28, such as the CLI in stellar/stellar-cli#2674, otherwise end up with two incompatible `stellar_xdr` crates in one dependency graph and cannot pass XDR types across this client's API.

### Known limitations

N/A